### PR TITLE
Add Romanian (ro_RO) and Vietnamese (vi_VN)

### DIFF
--- a/src/locale.js
+++ b/src/locale.js
@@ -227,11 +227,13 @@ export const LANG = {
     NO: ('no' : 'no'),
     PL: ('pl' : 'pl'),
     PT: ('pt' : 'pt'),
+    RO: ('ro' : 'ro'),
     RU: ('ru' : 'ru'),
     SK: ('sk' : 'sk'),
     SV: ('sv' : 'sv'),
     TH: ('th' : 'th'),
     TR: ('tr' : 'tr'),
+    VI: ('vi' : 'vi'),
     ZH: ('zh' : 'zh')
 };
 


### PR DESCRIPTION
Languages are now live in production.

Vietnam gains vi_VN as default
Romanian gets ro_RO as default, but will lose Rosetta Languages of es, fr, zh.