### PR TITLE
Reorder funding sources

### DIFF
--- a/src/funding.js
+++ b/src/funding.js
@@ -6,7 +6,6 @@ export const FUNDING = {
     ITAU:           ('itau' : 'itau'),
     CREDIT:         ('credit' : 'credit'),
     PAYLATER:       ('paylater' : 'paylater'),
-    CARD:           ('card' : 'card'),
     IDEAL:          ('ideal' : 'ideal'),
     SEPA:           ('sepa' : 'sepa'),
     BANCONTACT:     ('bancontact' : 'bancontact'),
@@ -24,7 +23,8 @@ export const FUNDING = {
     OXXO:           ('oxxo' : 'oxxo'),
     BOLETO:         ('boleto' : 'boleto'),
     WECHATPAY:      ('wechatpay' : 'wechatpay'),
-    MERCADOPAGO:    ('mercadopago' : 'mercadopago')
+    MERCADOPAGO:    ('mercadopago' : 'mercadopago'),
+    CARD:           ('card' : 'card') // keep this at end of list so that card fields render directly below "pay with card" button
 };
 
 export const FUNDING_BRAND_LABEL = {


### PR DESCRIPTION
Reorder funding sources so that SPB will display "Debit or Credit Card" button at the bottom of the stack (for better continuity with inline guest)

Note: will require updating this module in `paypal-checkout-components`

Before:
<img width="767" alt="Screen Shot 2020-11-10 at 5 00 21 PM" src="https://user-images.githubusercontent.com/25190326/98753260-c13d4d80-2378-11eb-97e6-5f19c4ddbe4c.png">

After:
<img width="767" alt="Screen Shot 2020-11-10 at 5 00 35 PM" src="https://user-images.githubusercontent.com/25190326/98753269-c69a9800-2378-11eb-901f-6e8e736b0b43.png">
