### PR TITLE
Add stage-alias query param

### DIFF
--- a/src/params.js
+++ b/src/params.js
@@ -43,7 +43,8 @@ export const SDK_QUERY_KEYS = {
     DISABLE_CARD:    ('disable-card' : 'disable-card'),
 
     INTEGRATION_DATE: ('integration-date' : 'integration-date'),
-    STAGE_HOST:       ('stage-host' : 'stage-host')
+    STAGE_HOST:       ('stage-host' : 'stage-host'),
+    STAGE_ALIAS:      ('stage-alias' : 'stage-alias')
 };
 
 export const COMPONENTS = {


### PR DESCRIPTION
This `stage-alias` query param is a new feature for making it easier to test in our stage environment. It is not supported in production or sandbox. It's deigned to allow individual components to be overwritten similar to the local npm run alias feature. This will allow teams to test their specific components in Stage by passing the tarball(s) urls in the query string. Ex:
```
/sdk/js?
  client-id=alc_client1&
  components=messages&
  stage-alias=https://uideploy--staticcontent--nate_test_4--ghe.preview.dev.paypalinc.com/upstream/bizcomponents/stage/package.tgz
```

