### PR TITLE
Add params for cdn-registry and version

### DIFF
--- a/src/params.js
+++ b/src/params.js
@@ -44,7 +44,9 @@ export const SDK_QUERY_KEYS = {
 
     INTEGRATION_DATE: ('integration-date' : 'integration-date'),
     STAGE_HOST:       ('stage-host' : 'stage-host'),
-    STAGE_ALIAS:      ('stage-alias' : 'stage-alias')
+    STAGE_ALIAS:      ('stage-alias' : 'stage-alias'),
+    CDN_REGISTRY:     ('cdn-registry' : 'cdn-registry'),
+    VERSION:          ('version' : 'version')
 };
 
 export const COMPONENTS = {


### PR DESCRIPTION
This PR adds two new params for making it easier to test the JS SDK in stage. Note that these new parameters are not designed to work in production, only stage.

1. **cdn-registry** - this param will be used to override the default cdn registry url with the one defined in the query string. Ex: 

```
https://localhost.paypal.com:8443/sdk/js?
  client-id=alc_client1&
  cdn-registry=https://uideploy--staticcontent--970c7deca4c0f--ghe.preview.dev.paypalinc.com/js-sdk-release
```

2. **version** -  this param will be used to define the specific version based on the available ones defined in the dist-tags. Ex:

```
{
    // available versions in dist-tags:
    "name": "@paypal/sdk-release",
    "dist-tags": {
        "latest": "5.0.229",
        "active-test": "5.0.227",
        "active-local": "5.0.227",
        "active-stage": "5.0.228",
        "active-sandbox": "5.0.227",
        "active-production": "5.0.227"
    },
```

Based on the dist-tags above, 5.0.227, 5.0.228, and 5.0.229 could be passed to this new version parameter.
```
https://localhost.paypal.com:8443/sdk/js?
  client-id=alc_client1&
  cdn-registry=https://uideploy--staticcontent--970c7deca4c0f--ghe.preview.dev.paypalinc.com/js-sdk-release&
  version=5.0.228
```
