### PR TITLE
Update paylater types

### DIFF
--- a/src/funding.js
+++ b/src/funding.js
@@ -53,6 +53,6 @@ export const WALLET_INSTRUMENT = {
 
 export const FUNDING_PRODUCTS = {
     PAY_IN_4: ('payIn4' : 'payIn4'),
-    FLEX:     ('flex' : 'flex'),
+    PAYLATER:     ('paylater' : 'paylater'),
     CREDIT:   ('credit' : 'credit')
 };

--- a/src/types.js
+++ b/src/types.js
@@ -24,7 +24,8 @@ export type PayPalEligibility = {|
 |};
 
 export type FundingProductEligibility = {|
-    eligible? : boolean
+    eligible? : boolean,
+    variant? : ?string
 |};
 
 export type PayLaterEligibility = {|
@@ -32,7 +33,7 @@ export type PayLaterEligibility = {|
     recommended? : ?boolean,
     products? : {|
         payIn4 : FundingProductEligibility,
-        flex : FundingProductEligibility
+        paylater : FundingProductEligibility
     |}
 |};
 


### PR DESCRIPTION
This PR adds `variant` and `paylater` types and removes `FLEX` const. Not yet returned from GraphQL but will be soon.