### PR TITLE
Add constant for validation_error

### DIFF
--- a/src/error.js
+++ b/src/error.js
@@ -1,0 +1,5 @@
+/* @flow */
+
+export const ERROR_CODE = {
+    VALIDATION_ERROR: 'validation_error'
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,12 @@
 /* @flow */
 
-export * from './locale';
-export * from './params';
-export * from './env';
-export * from './fpti';
-export * from './order';
-export * from './platform';
-export * from './funding';
 export * from './defaults';
+export * from './env';
+export * from './error';
+export * from './fpti';
+export * from './funding';
+export * from './locale';
+export * from './order';
+export * from './params';
+export * from './platform';
 export * from './types';


### PR DESCRIPTION
This constant is meant to be used both with checkount-components and smart-payment-buttons for client-side validation errors.