### PR TITLE
Add sdk script setting for disabling popups

### DIFF
--- a/src/params.js
+++ b/src/params.js
@@ -16,7 +16,8 @@ export const SDK_SETTINGS = {
     AMOUNT:                 ('data-amount' : 'data-amount'),
     CLIENT_METADATA_ID:     ('data-client-metadata-id' : 'data-client-metadata-id'),
     PAGE_TYPE:              ('data-page-type' : 'data-page-type'),
-    USER_EXPERIENCE_FLOW:   ('data-user-experience-flow' : 'data-user-experience-flow')
+    USER_EXPERIENCE_FLOW:   ('data-user-experience-flow' : 'data-user-experience-flow'),
+    DATA_POPUPS_DISABLED:   ('data-popups-disabled' : 'data-popups-disabled')
 };
 
 export const SDK_QUERY_KEYS = {


### PR DESCRIPTION
We'd like to add a new global sdk flag for when popups are not available, e.g. `<script src="..." data-popups-disabled />` The global setting can be shared by the Buttons component and other components. 

This new flag will be set by the merchant and will help support devices that do not support popups like Desktop applications with embedded browsers.