### PR TITLE
Fix flow error with `resolve` sub dependency

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -3,6 +3,7 @@
 .*/node_modules/flow-runtime
 .*/node_modules/npm
 .*/node_modules/eslint-plugin-compat
+.*/node_modules/resolve
 .*/dist/module
 [include]
 node_modules/grumbler-scripts/declarations.js

--- a/package.json
+++ b/package.json
@@ -43,8 +43,7 @@
   "readmeFilename": "README.md",
   "devDependencies": {
     "flow-bin": "0.129.0",
-    "grumbler-scripts": "^5.0.0",
-    "mocha": "8.0.1"
+    "grumbler-scripts": "^5.0.0"
   },
   "dependencies": {
     "cross-domain-utils": "^2.0.10",


### PR DESCRIPTION
This PR fixes the following flow error

https://github.com/paypal/paypal-sdk-constants/pull/72/checks#step:6:82

```
Error --------------------------------------- node_modules/resolve/test/resolver/malformed_package_json/package.json:2:1

Unexpected end of input, expected the token `}`

   2|
      



Found 1 error
```