### PR TITLE
add fpti missing keys

### DIFF
--- a/src/fpti.js
+++ b/src/fpti.js
@@ -60,7 +60,6 @@ export const FPTI_KEY = {
     TIME:                           ('time' : 'time'),
     OPTION_SELECTED:                ('optsel' : 'optsel'),
     USER_IDENTITY_METHOD:           ('user_identity_method' : 'user_identity_method'),
-    USER_ID:                        ('user_id' : 'user_id'),
     FIELDS_COMPONENT_SESSION_ID:    ('fields_component_session_id' : 'fields_component_session_id')
 };
 

--- a/src/fpti.js
+++ b/src/fpti.js
@@ -60,6 +60,7 @@ export const FPTI_KEY = {
     TIME:                           ('time' : 'time'),
     OPTION_SELECTED:                ('optsel' : 'optsel'),
     USER_IDENTITY_METHOD:           ('user_identity_method' : 'user_identity_method'),
+    USER_ID:                        ('user_id' : 'user_id'),
     FIELDS_COMPONENT_SESSION_ID:    ('fields_component_session_id' : 'fields_component_session_id')
 };
 

--- a/src/fpti.js
+++ b/src/fpti.js
@@ -57,6 +57,7 @@ export const FPTI_KEY = {
     PAY_NOW:                        ('pay_now' : 'pay_now'),
     STICKINESS_ID:                  ('stickiness_id' : 'stickiness_id'),
     TIMESTAMP:                      ('t' : 't'),
+    TIME:                           ('time' : 'time'),
     OPTION_SELECTED:                ('optsel' : 'optsel'),
     USER_IDENTITY_METHOD:           ('user_identity_method' : 'user_identity_method'),
     FIELDS_COMPONENT_SESSION_ID:    ('fields_component_session_id' : 'fields_component_session_id')


### PR DESCRIPTION
### Description

Some events logged in Amplitude are not appearing in the right order, this is because we are not sending the key `time` in the properties of each log. We are sending the key `t` however it is got as an extra event property, not as the timestamp of the event. 

Here there is a small experiment made locally using the library [beaver-logger](https://github.com/krakenjs/beaver-logger)

[In the first case](https://analytics.amplitude.com/paypal/project/295320/search/amplitude_id%3D356432994144), logs are sent just like are sent here, without the time key, and they appear disordered... 

[Here is the result](https://analytics.amplitude.com/paypal/project/295320/search/amplitude_id%3D356438516641) when we add the key time


### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

[Jira Ticket](https://engineering.paypalcorp.com/jira/browse/DTCHKINT-1067)


### Screenshots (Before)

![image](https://user-images.githubusercontent.com/17114924/151878876-e4bc7be9-9631-4e13-98f0-6b582953ecff.png)


### Screenshots (After)

![image](https://user-images.githubusercontent.com/17114924/151878785-8b5092b1-2937-4a08-904d-e68e85813652.png)

## Related PR

https://github.com/paypal/paypal-smart-payment-buttons/compare/main...gabrielo91:add-ket-time-to-fpti-logs?expand=1
