### PR TITLE
fix: rename boleto to match confirm-funding-source

### DIFF
--- a/dist/module/funding.js
+++ b/dist/module/funding.js
@@ -21,7 +21,7 @@ export var FUNDING = {
   ZIMPLER: 'zimpler',
   MAXIMA: 'maxima',
   OXXO: 'oxxo',
-  BOLETO: 'boleto',
+  BOLETOBANCARIO: 'boletobancario',
   WECHATPAY: 'wechatpay',
   MERCADOPAGO: 'mercadopago',
   MULTIBANCO: 'multibanco'

--- a/dist/module/funding.js
+++ b/dist/module/funding.js
@@ -21,6 +21,7 @@ export var FUNDING = {
   ZIMPLER: 'zimpler',
   MAXIMA: 'maxima',
   OXXO: 'oxxo',
+  BOLETO: 'boleto',
   BOLETOBANCARIO: 'boletobancario',
   WECHATPAY: 'wechatpay',
   MERCADOPAGO: 'mercadopago',

--- a/src/funding.js
+++ b/src/funding.js
@@ -23,6 +23,7 @@ export const FUNDING = {
     ZIMPLER:        ('zimpler' : 'zimpler'),
     MAXIMA:         ('maxima' : 'maxima'),
     OXXO:           ('oxxo' : 'oxxo'),
+    BOLETO:         ('boleto' : 'boleto'),
     BOLETOBANCARIO: ('boletobancario' : 'boletobancario'),
     WECHATPAY:      ('wechatpay' : 'wechatpay'),
     MERCADOPAGO:    ('mercadopago' : 'mercadopago'),

--- a/src/funding.js
+++ b/src/funding.js
@@ -23,10 +23,10 @@ export const FUNDING = {
     ZIMPLER:        ('zimpler' : 'zimpler'),
     MAXIMA:         ('maxima' : 'maxima'),
     OXXO:           ('oxxo' : 'oxxo'),
-    BOLETO:         ('boleto' : 'boleto'),
+    BOLETOBANCARIO: ('boletobancario' : 'boletobancario'),
     WECHATPAY:      ('wechatpay' : 'wechatpay'),
     MERCADOPAGO:    ('mercadopago' : 'mercadopago'),
-    MULTIBANCO:      ('multibanco' : 'multibanco')
+    MULTIBANCO:     ('multibanco' : 'multibanco')
 };
 
 export const FUNDING_BRAND_LABEL = {

--- a/src/types.js
+++ b/src/types.js
@@ -84,7 +84,7 @@ export type FundingEligibilityType = {|
     payu? : BasicEligibility,
     verkkopankki? : BasicEligibility,
     blik? : BasicEligibility,
-    boleto? : BasicEligibility,
+    boletobancario? : BasicEligibility,
     maxima? : BasicEligibility,
     oxxo? : BasicEligibility,
     trustly? : BasicEligibility,

--- a/src/types.js
+++ b/src/types.js
@@ -84,6 +84,7 @@ export type FundingEligibilityType = {|
     payu? : BasicEligibility,
     verkkopankki? : BasicEligibility,
     blik? : BasicEligibility,
+    boleto? : BasicEligibility,
     boletobancario? : BasicEligibility,
     maxima? : BasicEligibility,
     oxxo? : BasicEligibility,


### PR DESCRIPTION
Changed boleto to boletobancario

https://engineering.paypalcorp.com/jira/browse/DTALTPAY-919
Naming convention for Boleto / Boletobancario changed to match that of the confirm-payment-source call (boletobancario).