### PR TITLE
feat: upgrade to grumbler scripts 8

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,5 @@
 /* @flow */
 
 module.exports = {
-  extends: require.resolve(
-    "@krakenjs/grumbler-scripts/config/.eslintrc-browser"
-  ),
+  extends: "@krakenjs/eslint-config-grumbler/eslintrc-browser",
 };

--- a/.flowconfig
+++ b/.flowconfig
@@ -6,7 +6,6 @@
 .*/node_modules/resolve
 .*/dist/module
 [include]
-node_modules/@krakenjs/grumbler-scripts/declarations.js
 [libs]
 flow-typed
 [options]

--- a/babel.config.json
+++ b/babel.config.json
@@ -1,3 +1,3 @@
 {
-  "extends": "@krakenjs/grumbler-scripts/config/.babelrc-browser"
+  "extends": "@krakenjs/babel-config-grumbler/babel-browser"
 }

--- a/package.json
+++ b/package.json
@@ -45,8 +45,10 @@
   "license": "Apache-2.0",
   "readmeFilename": "README.md",
   "devDependencies": {
-    "@krakenjs/grumbler-scripts": "^7.0.0",
+    "@krakenjs/grumbler-scripts": "^8.0.3",
+    "cross-env": "^7.0.3",
     "flow-bin": "0.129.0",
+    "flow-typed": "^3.8.0",
     "husky": "^8.0.1",
     "lint-staged": "^13.0.3",
     "prettier": "2.7.1"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 /* @flow */
 /* eslint import/no-nodejs-modules: off */
 
-import { getWebpackConfig } from "@krakenjs/grumbler-scripts/config/webpack.config";
+import { getWebpackConfig } from "@krakenjs/webpack-config-grumbler";
 
 const FILE_NAME = "paypal-sdk-constants";
 const MODULE_NAME = "ppsdkconstants";


### PR DESCRIPTION
[DTPPSDK-935](https://engineering.paypalcorp.com/jira/browse/DTPPSDK-935)

* Migrated to grumbler scripts v8.  
* Added `flow-typed` and `cross-env` as explicit dev-dependencies.  