### PR TITLE
Add SDK token to SDK settings constant

### DIFF
--- a/src/params.js
+++ b/src/params.js
@@ -21,6 +21,7 @@ export const SDK_SETTINGS = {
   USER_EXPERIENCE_FLOW:
     ("data-user-experience-flow": "data-user-experience-flow"),
   POPUPS_DISABLED: ("data-popups-disabled": "data-popups-disabled"),
+  SDK_TOKEN: ("data-sdk-client-token": "data-sdk-client-token"),
 };
 
 export const SDK_QUERY_KEYS = {


### PR DESCRIPTION
Adds the constant for SDK token data atrribute, we will guard usage in SDK client for any alpha features using it