### PR TITLE
Add hosted-buttons component

### DIFF
--- a/src/params.js
+++ b/src/params.js
@@ -56,8 +56,9 @@ export const SDK_QUERY_KEYS = {
 
 export const COMPONENTS = {
   BUTTONS: ("buttons": "buttons"),
-  HOSTED_FIELDS: ("hosted-fields": "hosted-fields"),
   CARD_FIELDS: ("card-fields": "card-fields"),
+  HOSTED_BUTTONS: ("hosted-buttons": "hosted-buttons"),
+  HOSTED_FIELDS: ("hosted-fields": "hosted-fields"),
 };
 
 export const DEBUG = {


### PR DESCRIPTION
This PR adds a new component `hosted-buttons` so that we can load the SDK with a specific component namespace: `?components=hosted-buttons` 

As of today, we are loading the hosted-buttons component under the existing `buttons` component, but want to split it out into its own component so that we can add features without increasing the existing `buttons` bundle size.