### PR TITLE
add FPTI key for referrer_domain

### DIFF
--- a/src/fpti.js
+++ b/src/fpti.js
@@ -13,6 +13,7 @@ export const FPTI_KEY = {
   CONTEXT_ID: ("context_id": "context_id"),
   CONTEXT_TYPE: ("context_type": "context_type"),
   REFERER: ("referer_url": "referer_url"),
+  REFERRER_DOMAIN: ("referrer_domain", "referrer_domain"),
   MERCHANT_DOMAIN: ("merchant_domain": "merchant_domain"),
   PAY_ID: ("pay_id": "pay_id"),
   SELLER_ID: ("seller_id": "seller_id"),


### PR DESCRIPTION
## Overview

This PR adds a new key `referrer_domain` that will be used with FPTI and `xprops.referrerDomain`.

I added this new key next to the existing `REFERER` key to explicitly call out that there are two different keys that are related to referrer. The existing `REFERER` is used [here](https://github.com/paypal/paypal-smart-payment-buttons/blob/c268be3d0b18ff0ecaa11df646e74c8787ec03ff/src/lib/logger.js#L133) but does not send the correct URL. The analytics team would like to keep both of these keys (`referer_url` and `referrer_domain`). 

## Related Changes

- https://github.com/paypal/paypal-checkout-components/pull/2296

## Future Changes

- pass `xprops.referrerDomain` to FPTI around here https://github.com/paypal/paypal-smart-payment-buttons/blob/c268be3d0b18ff0ecaa11df646e74c8787ec03ff/src/lib/logger.js#L133