### PR TITLE
Adding DINERS

### DIFF
--- a/src/funding.js
+++ b/src/funding.js
@@ -43,6 +43,7 @@ export const CARD = {
   ELO: ("elo": "elo"),
   JCB: ("jcb": "jcb"),
   CUP: ("cup": "cup"),
+  DINERS: ("diners": "diners"),
 };
 
 export const WALLET_INSTRUMENT = {


### PR DESCRIPTION
### OVERVIEW
---

This PR to add new CARD type that is needed on unbranded DINERS enablement. As part of hosted-field requires this value to generate the funding eligibility for DINERS in another component. Due to missing DINERS in the constants, the funding eligibility did not generated correctly. 

