### PR TITLE
Adding MAESTRO card brand to funding.js

### DIFF
--- a/src/funding.js
+++ b/src/funding.js
@@ -44,6 +44,7 @@ export const CARD = {
   JCB: ("jcb": "jcb"),
   CUP: ("cup": "cup"),
   DINERS: ("diners": "diners"),
+  MAESTRO: ("maestro": "maestro"),
 };
 
 export const WALLET_INSTRUMENT = {


### PR DESCRIPTION
Currently, MAESTRO card brand is not supported in SDK V2 (card fields). To enable the maestro-based transactions in SDK V2, it is added to funding.js.