### PR TITLE
Adding deprecated APM - maxima, zimpler to funding.js

### DIFF
--- a/src/apm.js
+++ b/src/apm.js
@@ -21,4 +21,7 @@ export const APM_LIST = [
   FUNDING.MULTIBANCO,
   FUNDING.SATISPAY,
   FUNDING.PAIDY,
+  // deprecated APMs will be removed soon
+  FUNDING.MAXIMA,
+  FUNDING.ZIMPLER,
 ];

--- a/src/funding.js
+++ b/src/funding.js
@@ -27,6 +27,9 @@ export const FUNDING = {
   MULTIBANCO: ("multibanco": "multibanco"),
   SATISPAY: ("satispay": "satispay"),
   PAIDY: ("paidy": "paidy"),
+  // deprecated APMs will be removed soon
+  ZIMPLER: ("zimpler": "zimpler"),
+  MAXIMA: ("maxima": "maxima"),
 };
 
 export const FUNDING_BRAND_LABEL = {

--- a/src/types.js
+++ b/src/types.js
@@ -95,4 +95,7 @@ export type FundingEligibilityType = {|
   multibanco?: BasicEligibility,
   satispay?: BasicEligibility,
   paidy?: BasicEligibility,
+  // deprecated APMs will be removed soon
+  zimpler?: BasicEligibility,
+  maxima?: BasicEligibility,
 |};

--- a/src/types.js
+++ b/src/types.js
@@ -55,6 +55,8 @@ export type CardVendorsEligibility = {|
   elo?: CardVendorEligibility,
   jcb?: CardVendorEligibility,
   cup?: CardVendorEligibility,
+  maestro?: CardVendorEligibility,
+  diners?: CardVendorEligibility,
 |};
 
 export type CardEligibility = {|


### PR DESCRIPTION
The deprecated APMs - maxima, zimpler are added back to sync with other SDK components. These APMs will be removed from all the components together.