### PR TITLE
Remove JS_SDK_LIBRARIES

### DIFF
--- a/src/params.js
+++ b/src/params.js
@@ -1,11 +1,5 @@
 /* @flow */
 
-export const JS_SDK_LIBRARIES = {
-  PAYPAL_JS: ("paypal-js": "paypal-js"),
-  RAW_SCRIPT: ("raw-script": "raw-script"),
-  REACT_PAYPAL_JS: ("react-paypal-js": "react-paypal-js"),
-};
-
 export const SDK_PATH = ("/sdk/js": "/sdk/js");
 
 export const SDK_SETTINGS = {


### PR DESCRIPTION
### Description

@gregjopa, @westeezy, and I had a solid chat about DTPPCPSDK-1482 where it was decided we'd remove `JS_SDK_LIBRARIES` from `@paypal/sdk-constants` and hardcode values. This was inspired by the difficulty of adding `@paypal/sdk-constants` as a dependency of `paypal-js`.