### PR TITLE
Enable eftpos card brand 

### DIFF
--- a/src/funding.js
+++ b/src/funding.js
@@ -48,6 +48,7 @@ export const CARD = {
   CUP: ("cup": "cup"),
   DINERS: ("diners": "diners"),
   MAESTRO: ("maestro": "maestro"),
+  EFTPOS: ("eftpos": "eftpos"),
 };
 
 export const WALLET_INSTRUMENT = {

--- a/src/types.js
+++ b/src/types.js
@@ -57,6 +57,7 @@ export type CardVendorsEligibility = {|
   cup?: CardVendorEligibility,
   maestro?: CardVendorEligibility,
   diners?: CardVendorEligibility,
+  eftpos?: CardVendorEligibility,
 |};
 
 export type CardEligibility = {|


### PR DESCRIPTION
EFTPOS is a card brand used predominantly in the AU country region, with dual card brands Visa/MC or standalone card brand. This change will enable the EFTPOS card brand support in the SDK and currently, we are working on alpha version testing.


EFTPOS wiki - https://en.wikipedia.org/wiki/EFTPOS