### PR TITLE
Added WEB_SDK_BRIDGE_PATH

### DIFF
--- a/src/params.js
+++ b/src/params.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 export const SDK_PATH = ("/sdk/js": "/sdk/js");
-export const WEB_SDK_PATH = ("/web-sdk": "/web-sdk");
+export const WEB_SDK_BRIDGE_PATH = ("/web-sdk/v6/bridge": "/web-sdk/v6/bridge");
 
 export const SDK_SETTINGS = {
   AMOUNT: ("data-amount": "data-amount"),

--- a/src/params.js
+++ b/src/params.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 export const SDK_PATH = ("/sdk/js": "/sdk/js");
+export const WEB_SDK_PATH = ("/web-sdk": "/web-sdk");
 
 export const SDK_SETTINGS = {
   AMOUNT: ("data-amount": "data-amount"),


### PR DESCRIPTION
This constant will be used by `@paypal/sdk-client` to validate and load the NextGen SDK bridge used to communicate back to a merchant page running the NextGen SDK.