### PR TITLE
Removing flow_typed from build script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,8 +23,5 @@ jobs:
         with:
           useLockFile: false
 
-      - name: ▶️ Run flow-typed script
-        run: npm run flow-typed
-
       - name: ▶️ Run build script
         run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -46,9 +46,6 @@ jspm_packages
 # Yarn Integrity file
 .yarn-integrity
 
-# Flow Typed
-flow-typed
-
 .idea
 
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "webpack": "babel-node --plugins=transform-es2015-modules-commonjs ./node_modules/.bin/webpack --progress",
     "format": "prettier --write --ignore-unknown .",
     "format:check": "prettier --check .",
-    "test": "npm run format:check && npm run lint && npm run flow-typed && npm run flow",
+    "test": "npm run format:check && npm run lint && npm run flow",
     "build": "npm run test && npm run babel && npm run webpack",
     "release": "./publish.sh",
     "release:patch": "./publish.sh patch",


### PR DESCRIPTION
We see the "build stage" in the pipeline is failing because of the flow_typed script, to fix that removed the "flow_typed" library reference from the build script.