### PR TITLE
Add Carte Bancaire to the list of eligible vendors

### DIFF
--- a/src/funding.js
+++ b/src/funding.js
@@ -49,6 +49,7 @@ export const CARD = {
   DINERS: ("diners": "diners"),
   MAESTRO: ("maestro": "maestro"),
   EFTPOS: ("eftpos": "eftpos"),
+  CB_NATIONALE: ("cb-nationale": "cb-nationale"),
 };
 
 export const WALLET_INSTRUMENT = {


### PR DESCRIPTION
Add Carte Bancaire to the list of eligible vendors to support co-badged cards when trying to complete payment with this network.