### PR TITLE
feat: update the constant for cb nationale as per gql requirements

### DIFF
--- a/src/funding.js
+++ b/src/funding.js
@@ -49,7 +49,7 @@ export const CARD = {
   DINERS: ("diners": "diners"),
   MAESTRO: ("maestro": "maestro"),
   EFTPOS: ("eftpos": "eftpos"),
-  CB_NATIONALE: ("cb-nationale": "cb-nationale"),
+  CB_NATIONALE: ("cb_nationale": "cb_nationale"),
 };
 
 export const WALLET_INSTRUMENT = {


### PR DESCRIPTION
**Description**
Currently, this constant is utilized in our gql API as well as the SDK FI eligibility logic. Due to pre-defined constraints around the string casing of the Card networks, we want to make the `cb_nationale` constant uniform across the unbranded flow. 