### PR TITLE
Adding global_session_id const to fpti

### DIFF
--- a/src/fpti.js
+++ b/src/fpti.js
@@ -51,6 +51,7 @@ export const FPTI_KEY = {
   FLOW: ("flow": "flow"),
   FUNDING_COUNT: ("eligible_payment_count": "eligible_payment_count"),
   FUNDING_LIST: ("eligible_payment_methods": "eligible_payment_methods"),
+  GLOBAL_SESSION_UID: ("global_session_id": "global_session_id"),
   HOSTED_BUTTON_ID: ("hosted_button_id": "hosted_button_id"),
   INTEGRATION_IDENTIFIER: ("integration_identifier": "integration_identifier"),
   IS_VAULT: ("is_vault": "is_vault"),


### PR DESCRIPTION
## What is the purpose of this PR?
Retrieve `globalSessionID` value from a new session created by Messaging components when more than a namespace are being used at the same time. Besides retrieving it, we should log the data on tracking button events on a prop named `global_session_id`

## Type of change <!-- Check all that best describe your change. -->

- [x] New feature (backward compatible change that adds new capability).
- [ ] UI change
- [ ] Bug fix.
- [ ] Breaking change (backward incompatible change). Provide references to customer impact and communication.
- [ ] Refactor (no functional change)

## Testing Plan

Here's the step by step to check if this change is working, but both changes on `paypal-sdk-client`, `smartcomponentnodeweb`, `paypal-sdk-constants` and `paypal-checkout-components` are needed

- Open your site, network tab and wait for logger requests
- Wait for any button event like `process_button_load`
- Check if `global_session_id` property exists. IT SHOULDN'T
- After it, go to console, copy and paste this:
```
window.localStorage.__paypal_global_5_0_500_storage__ = JSON.stringify({
   globalSessionID: "uid_testID",
})
```
- Reload the page and check the same logger, the `global_session_id` should be present and with uid_testID as its value
