### PR TITLE
add user activation fpti key

### DIFF
--- a/src/fpti.js
+++ b/src/fpti.js
@@ -105,6 +105,8 @@ export const FPTI_KEY = {
   SELECTED_CARD_TYPE: ("selected_card_type": "selected_card_type"),
   CURRENCY: ("currency": "currency"),
   AMOUNT: ("amount": "amount"),
+  USER_ACTIVATION_IS_ACTIVE:
+    ("usr_activation_is_active", "usr_activation_is_active"),
 };
 
 export const FPTI_USER_ACTION = {


### PR DESCRIPTION
Adds FPTI key for `usr_activation_is_active` field, intended to be used for tracking `UserActivation.isActive`.